### PR TITLE
Fix prop type handling in MongoDB adapter

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -300,7 +300,10 @@ MongoDB.prototype.fromDatabase = function (model, data) {
         if (!props[key]) {
             return;
         }
-        if (props[key].type.name.toString().toLowerCase() === 'date') {
+        var propType = props[key].type && props[key].type.name
+            ? props[key].type.name.toString().toLowerCase()
+            : '';
+        if (propType === 'date') {
             if (data[key]) {
                 clean[key] = new Date(data[key]);
             } else {


### PR DESCRIPTION
## Summary
- handle missing property type in MongoDB adapter's `fromDatabase`

## Testing
- `npm test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684b4d859e80832fb548be3a20b70bb7