### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,43 @@
+name: Publish package to npm
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - id: version
+        name: Check package.json version change
+        run: |
+          prev_version=$(git show ${{ github.event.before }}:package.json | jq -r .version)
+          curr_version=$(jq -r .version package.json)
+          echo "previous=$prev_version" >> $GITHUB_OUTPUT
+          echo "current=$curr_version" >> $GITHUB_OUTPUT
+          if [ "$prev_version" != "$curr_version" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dependencies
+        if: steps.version.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- add Github Actions workflow to publish package when the version changes

## Testing
- `npm test` *(fails: `No rule to make target 'test'`)*

------
https://chatgpt.com/codex/tasks/task_e_684bc19bd430832fb9f717b149b32eb1