### PR TITLE
Handle no-results more gracefully

### DIFF
--- a/lib/abstract-class.js
+++ b/lib/abstract-class.js
@@ -507,21 +507,23 @@ AbstractClass.find = AbstractClass.exec = AbstractClass.run = AbstractClass.all 
         params = buildQuery(params, this);
         var Constr = this;
         this.schema.adapter.all(this.modelName, params, function (err, data) {
-            if (!err && data && data.map) {
+            if (err) {
+                if (!callback) p.reject(err);
+                return callback && callback(err, null);
+            }
+
+            if (data && data.map && data.length > 0) {
                 data.forEach(function (d, i) {
                     var obj = new Constr();
                     obj._initProperties(d, false);
                     data[i] = obj;
                 });
-                // if (data && data.countBeforeLimit) {
-                //     data['countBeforeLimit'] = data.countBeforeLimit;
-                // }
-                if(!callback) p.resolve(data);
-                return callback && callback(err, data);
-            } else {
-                if(!callback) p.reject(err);
-                return callback && callback(err, []);
+                if (!callback) p.resolve(data);
+                return callback && callback(null, data);
             }
+
+            if (!callback) p.resolve(null);
+            return callback && callback(null, null);
         });
         return p.promise;
     }

--- a/lib/adapters/memory.js
+++ b/lib/adapters/memory.js
@@ -69,7 +69,8 @@ Memory.prototype.exists = function exists(model, id, callback) {
 
 Memory.prototype.findById = function findById(model, id, callback) {
     process.nextTick(function () {
-        callback(null, this.cache[model][id]);
+        var data = this.cache[model][id];
+        callback(null, typeof data === 'undefined' ? null : data);
     }.bind(this));
 };
 


### PR DESCRIPTION
## Summary
- avoid failing when `.all()` finds no results by returning `null`
- normalize memory adapter `findById` to return `null` when record not found

## Testing
- `npm test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684bdd9929d4832fb5265decd4252f3d